### PR TITLE
Save last manufacturer choice and add JLCPCB with stencil

### DIFF
--- a/action_menu_gerber_zipper/Manufacturers/JLCPCB_w-stencil.json
+++ b/action_menu_gerber_zipper/Manufacturers/JLCPCB_w-stencil.json
@@ -1,0 +1,66 @@
+{
+  "Name":"JLCPCB with stencil",
+  "Description":"Make Gerber-files/Zip for JLCPCB,  Upto 8 layers, with Stencil",
+  "URL":"https://jlcpcb.com/",
+  "GerberDir":"Gerber",
+  "ZipFilename":"*-JLCPCB.ZIP",
+  "Layers": {
+    "F.Cu":"*-F.Cu.gbr",
+    "B.Cu":"*-B.Cu.gbr",
+    "F.Paste":"*-F.Paste.gbr",
+    "B.Paste":"*-B.Paste.gbr",
+    "F.SilkS":"*-F.SilkS.gbr",
+    "B.SilkS":"*-B.SilkS.gbr",
+    "F.Mask":"*-F.Mask.gbr",
+    "B.Mask":"*-B.Mask.gbr",
+    "Edge.Cuts":"*-Edge.Cuts.gbr",
+    "In1.Cu":"*-In1.Cu.gbr",
+    "In2.Cu":"*-In2.Cu.gbr",
+    "In3.Cu":"*-In3.Cu.gbr",
+    "In4.Cu":"*-In4.Cu.gbr",
+    "In5.Cu":"*-In5.Cu.gbr",
+    "In6.Cu":"*-In6.Cu.gbr"
+  },
+  "PlotBorderAndTitle":false,
+  "PlotFootprintValues":false,
+  "PlotFootprintReferences":true,
+  "ForcePlotInvisible":false,
+  "ExcludeEdgeLayer":true,
+  "ExcludePadsFromSilk":true,
+  "DoNotTentVias":false,
+  "UseAuxOrigin":false,
+  "LineWidth":0.1,
+
+  "CoodinateFormat46":true,
+  "SubtractMaskFromSilk":true,
+  "UseExtendedX2format": false,
+  "IncludeNetlistInfo":false,
+
+  "Drill": {
+    "Drill":"*-PTH.drl",
+    "DrillMap":"",
+    "NPTH":"*-NPTH.drl",
+    "NPTHMap":"",
+    "Report":""
+  },
+  "MirrorYAxis":false,
+  "MinimalHeader":false,
+  "MergePTHandNPTH":false,
+  "RouteModeForOvalHoles":true,
+  "DrillUnitMM":false,
+  "ZerosFormat":{
+    "DecimalFormat":true,
+    "SuppressLeading":false,
+    "SuppressTrailing":false,
+    "KeepZeros":false
+  },
+  "MapFileFormat":{
+    "HPGL":false,
+    "PostScript":true,
+    "Gerber":false,
+    "DXF":false,
+    "SVG":false,
+    "PDF":false
+  },
+  "OptionalFiles":[]
+}

--- a/action_menu_gerber_zipper/gerber_zipper_action.py
+++ b/action_menu_gerber_zipper/gerber_zipper_action.py
@@ -341,6 +341,15 @@ class GerberZipperAction( pcbnew.ActionPlugin ):
         class Dialog(wx.Dialog):
             def __init__(self, parent):
                 global strtab
+                prefix_path = os.path.join(os.path.dirname(__file__))
+                settings_fname = os.path.join(prefix_path, 'settings.json');
+                self.plugin_settings_data = {}
+                if os.path.exists(settings_fname):
+                	self.plugin_settings_data = json.load(open(settings_fname))
+                else:
+                    self.plugin_settings_data["default"] = 0;
+                    json.dump(self.plugin_settings_data, open(settings_fname, "x"))
+
                 self.icon_file_name = os.path.join(os.path.dirname(__file__), 'icon.png')
                 self.manufacturers_dir = os.path.join(os.path.dirname(__file__), 'Manufacturers')
                 manufacturers_list = glob.glob('%s/*.json' % self.manufacturers_dir)
@@ -379,7 +388,7 @@ class GerberZipperAction( pcbnew.ActionPlugin ):
                 wx.StaticText(self.panel, wx.ID_ANY, getstr('DESCRIPTION'),size=(120,25), pos=(20,170))
                 self.label = wx.StaticText(self.panel, wx.ID_ANY, '',size=(500,25), pos=(150,170))
 
-                self.manufacturers.SetSelection(0)
+                self.manufacturers.SetSelection(self.plugin_settings_data["default"])
                 self.detailbtn = wx.ToggleButton(self.panel, wx.ID_ANY, getstr('DETAIL'),size=(150,25),pos=(20,200))
                 self.execbtn = wx.Button(self.panel, wx.ID_ANY, getstr('EXEC'),size=(200,25),pos=(200,200))
                 self.clsbtn = wx.Button(self.panel, wx.ID_ANY, getstr('CLOSE'),size=(150,25),pos=(410,200))
@@ -394,6 +403,11 @@ class GerberZipperAction( pcbnew.ActionPlugin ):
 
             def Select(self,n):
                 self.settings = self.json_data[n]
+                # Save this selection as default
+                self.plugin_settings_data["default"] = n;
+                prefix_path = os.path.join(os.path.dirname(__file__))
+                settings_fname = os.path.join(prefix_path, 'settings.json');                
+                json.dump(self.plugin_settings_data, open(settings_fname,"w"))
                 self.label.SetLabel(self.settings.get('Description', ''))
                 self.url.SetValue(self.settings.get('URL','---'))
                 self.gerberdir.SetValue(self.settings.get('GerberDir','Gerber'))

--- a/action_menu_gerber_zipper/gerber_zipper_action.py
+++ b/action_menu_gerber_zipper/gerber_zipper_action.py
@@ -399,7 +399,7 @@ class GerberZipperAction( pcbnew.ActionPlugin ):
                 self.detailbtn.Bind(wx.EVT_TOGGLEBUTTON, self.OnDetail)
 
                 self.editor = Editor(self.panel)
-                self.Select(0)
+                self.Select(self.plugin_settings_data["default"])
 
             def Select(self,n):
                 self.settings = self.json_data[n]


### PR DESCRIPTION
It is very handy to store last choice, as often people work with specific manufacturer for several projects and sometimes generate gerbers for several boards at once.

And thank you for great automation tool!