### PR TITLE
Quick and dirty fix for HiDPI display environment. Simply make dialog resizable

### DIFF
--- a/action_menu_gerber_zipper/gerber_zipper_action.py
+++ b/action_menu_gerber_zipper/gerber_zipper_action.py
@@ -368,7 +368,8 @@ class GerberZipperAction( pcbnew.ActionPlugin ):
                     print (fname)
                     strtab[fname] = json.load(open(fpath))
 
-                wx.Dialog.__init__(self, parent, id=-1, title='Gerber-Zipper '+version, size=(680,270))
+                wx.Dialog.__init__(self, parent, id=-1, title='Gerber-Zipper '+version, size=(680, 270),
+                                   style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
                 self.panel = wx.Panel(self)
                 icon=wx.Icon(self.icon_file_name)
                 self.SetIcon(icon)


### PR DESCRIPTION
In HiDPI w/ 150% scaling on windows, cannot press any buttons because they are not shown.
I tried to use wx.Window.FromDIP for better fixing, but it is not implemented on wxPython 3.0.2.