### PR TITLE
Kicad Gerberzipper default language should not be Portuguese

### DIFF
--- a/action_menu_gerber_zipper/gerber_zipper_action.py
+++ b/action_menu_gerber_zipper/gerber_zipper_action.py
@@ -150,6 +150,7 @@ def getid(s):
 
 def getstr(s):
     lang = wx.Locale.GetCanonicalName(wx.GetLocale())
+    lang = lang if lang else 'default'
     tab = strtab['default']
     if (lang in strtab):
         tab = strtab[lang]


### PR DESCRIPTION
Hi there 👋! Today I downloaded your plugin and noticed that the plugin's default language is Portuguese. I assume this was not intended (Sorry Portuguese people). I'm on MacOS (en_us) and my KiCad's language settings are set to 'Default'. I found out that the `lang` variable in the `getstr` function is `None`, which somehow causes the function to retrieve the Portuguese labels. To fix this I have made sure that `lang` is set to `'default'` if it is `None`.